### PR TITLE
Allow passing headers object with null prototype

### DIFF
--- a/src/Headers.test.ts
+++ b/src/Headers.test.ts
@@ -40,6 +40,13 @@ describe('constructor()', () => {
     expect(headers.get('accept')).toEqual('*/*')
   })
 
+  it('can be created given an object with an undefined constructor', () => {
+    const obj = Object.create(null)
+    obj.accept = '*/*'
+    const headers = new Headers(obj)
+    expect(headers.get('accept')).toEqual('*/*')
+  })
+
   it('duplicates values for the same header names with different casing', () => {
     const headers = new Headers({
       'accept-encoding': 'gzip, deflate, br',

--- a/src/Headers.ts
+++ b/src/Headers.ts
@@ -25,7 +25,7 @@ export class Headers {
      * `Headers` because that class may not be defined in Node or jsdom.
      */
     if (
-      ['Headers', 'HeadersPolyfill'].includes(init?.constructor.name) ||
+      ['Headers', 'HeadersPolyfill'].includes(init?.constructor?.name) ||
       init instanceof Headers ||
       (typeof globalThis.Headers !== 'undefined' &&
         init instanceof globalThis.Headers)


### PR DESCRIPTION
Currently, if an object is created with the null prototype, e.g.

```typescript
const headers = Object.create(null);
```

attempting to instantiate a `Headers` object with this polyfill throws an error:

```
TypeError: Cannot read properties of undefined (reading 'name')
```

because `headers.constructor` is undefined.